### PR TITLE
Fix: Correct date display in WithdrawRequestCard.js by using toLocale…

### DIFF
--- a/enatega-multivendor-rider/src/components/WalletCard/WithDrawRequestCard.js
+++ b/enatega-multivendor-rider/src/components/WalletCard/WithDrawRequestCard.js
@@ -4,7 +4,7 @@ import styles from './style'
 import TextDefault from '../Text/TextDefault/TextDefault'
 import colors from '../../utilities/colors'
 import ConfigurationContext from '../../context/configuration'
-import {useTranslation} from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 
 const STATUS_COLORS = {
   CANCELLED: colors.orderUncomplete,
@@ -13,7 +13,7 @@ const STATUS_COLORS = {
 }
 
 const RequestCard = ({ item }) => {
-  const {t} = useTranslation()
+  const { t } = useTranslation()
   const configuration = useContext(ConfigurationContext)
   return (
     <View style={[styles.container, styles.bgBlack]}>
@@ -48,7 +48,14 @@ const RequestCard = ({ item }) => {
       />
       <RequestRow
         label={t('requestTime')}
-        value={new Date(item?.requestTime).toDateString()}
+        value={new Date(item?.requestTime).toLocaleString([], {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true
+        })}
         color={colors.white}
       />
       <RequestRow


### PR DESCRIPTION
The date in the Withdraw Requests section was showing one day behind due to improper timezone handling in WithdrawRequestCard.js. Updated the date formatting logic in WithdrawRequestCard.js to use toLocaleString, ensuring dates now reflect the correct local date 

Tested on:
OS: Windows 11 (WSL/Ubuntu)
Browser: Chrome (Latest)